### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 # Based on https://github.com/mvdan/github-actions-golang
 on: [push, pull_request]
 name: Tests
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/qba73/geonames/security/code-scanning/1](https://github.com/qba73/geonames/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only runs Go tests and does not require write permissions, we will set `contents: read` as the minimal required permission. This ensures that the workflow has the least privileges necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
